### PR TITLE
feat: add win32-ia32 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Next, construct the URL of the update server and tell
 
 ```javascript
 const server = 'https://update.electronjs.org'
-const feed = `${server}/OWNER/REPO/${process.platform}/${app.getVersion()}`
+const feed = `${server}/OWNER/REPO/${process.platform}-${process.arch}/${app.getVersion()}`
 
 autoUpdater.setFeedURL(feed)
 ```
 
-As the final step, check for updates. The example below will check every 10 
+As the final step, check for updates. The example below will check every 10
 minutes:
 
 ```javascript

--- a/index.js
+++ b/index.js
@@ -115,7 +115,14 @@ class Updates {
     let latest = await this.cache.get(key)
     if (latest) {
       log.info({ key }, 'cache hit')
-      return latest[platform] ? latest[platform] : null
+      // reuse cache entries using the old non-arch-aware format
+      if (platform === 'darwin-x64' && latest.darwin) {
+        return latest.darwin
+      } else if (platform === 'win32-x64' && latest.win32) {
+        return latest.win32
+      } else {
+        return latest[platform] || null
+      }
     }
 
     let lock
@@ -186,9 +193,17 @@ class Updates {
             notes: release.body
           }
         }
-        if (latest['darwin-x64'] && latest['win32-x64'] && latest['win32-ia32']) { break }
+        if (
+          latest['darwin-x64'] &&
+          latest['win32-x64'] &&
+          latest['win32-ia32']
+        ) {
+          break
+        }
       }
-      if (latest['darwin-x64'] && latest['win32-x64'] && latest['win32-ia32']) { break }
+      if (latest['darwin-x64'] && latest['win32-x64'] && latest['win32-ia32']) {
+        break
+      }
     }
 
     for (const key of ['win32-x64', 'win32-ia32']) {

--- a/index.js
+++ b/index.js
@@ -113,16 +113,14 @@ class Updates {
   async cachedGetLatest (account, repository, platform) {
     const key = `${account}/${repository}`
     let latest = await this.cache.get(key)
+
     if (latest) {
-      log.info({ key }, 'cache hit')
       // reuse cache entries using the old non-arch-aware format
-      if (platform === 'darwin-x64' && latest.darwin) {
-        return latest.darwin
-      } else if (platform === 'win32-x64' && latest.win32) {
-        return latest.win32
-      } else {
-        return latest[platform] || null
-      }
+      if (latest.darwin) latest['darwin-x64'] = latest.darwin
+      if (latest.win32) latest['win32-x64'] = latest.win32
+
+      log.info({ key }, 'cache hit')
+      return latest[platform] || null
     }
 
     let lock

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,4 +1,5 @@
 {
+  "name": "update.electronjs.org",
   "requires": true,
   "lockfileVersion": 1,
   "dependencies": {
@@ -2254,9 +2255,9 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
           }
         },
         "fs.realpath": {
@@ -2349,8 +2350,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
+            "ajv": "^4.9.1",
+            "har-schema": "^1.0.5"
           }
         },
         "has-unicode": {
@@ -2411,7 +2412,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "number-is-nan": "1.0.1"
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-typedarray": {
@@ -2503,7 +2504,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "mime-db": "1.27.0"
+            "mime-db": "~1.27.0"
           }
         },
         "minimatch": {
@@ -2511,7 +2512,7 @@
           "bundled": true,
           "dev": true,
           "requires": {
-            "brace-expansion": "1.1.7"
+            "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
@@ -2617,8 +2618,8 @@
           "dev": true,
           "optional": true,
           "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
+            "os-homedir": "^1.0.0",
+            "os-tmpdir": "^1.0.0"
           }
         },
         "path-is-absolute": {

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+  "name": "update.electronjs.org",
   "scripts": {
     "start": "nodemon bin/update-server.js",
     "test": "prettier-standard '**/*.js' && standard && cross-env NODE_ENV=test nyc tap test/*.js"

--- a/test/index.js
+++ b/test/index.js
@@ -147,8 +147,10 @@ nock('https://github.com')
   .get('/owner/repo-darwin/releases/download/v1.0.0/RELEASES')
   .reply(404)
   .get('/owner/repo-win32-zip/releases/download/v1.0.0/RELEASES')
+  .times(2)
   .reply(404)
   .get('/owner/repo-no-releases/releases/download/v1.0.0/RELEASES')
+  .times(2)
   .reply(404)
 
 test('Updates', async t => {
@@ -299,7 +301,7 @@ test('Updates', async t => {
         const body = await res.text()
         t.equal(
           body,
-          'No updates found (needs asset containing win32-x64 or .exe in public repository)'
+          'No updates found (needs asset containing win32-{x64,ia32} or .exe in public repository)'
         )
       })
     })
@@ -311,7 +313,7 @@ test('Updates', async t => {
         const body = await res.text()
         t.equal(
           body,
-          'Unsupported platform: "linux". Supported: darwin, win32.'
+          'Unsupported platform: "linux". Supported: darwin-x64, win32-x64, win32-ia32.'
         )
       })
     })
@@ -321,7 +323,10 @@ test('Updates', async t => {
         const res = await fetch(`${address}/owner/repo/os/0.0.0`)
         t.equal(res.status, 404)
         const body = await res.text()
-        t.equal(body, 'Unsupported platform: "os". Supported: darwin, win32.')
+        t.equal(
+          body,
+          'Unsupported platform: "os". Supported: darwin-x64, win32-x64, win32-ia32.'
+        )
       })
     })
   })


### PR DESCRIPTION
This extends the url format from

```js
`host/account/repository/${process.platform}/${pkg.version}`
```

to

```js
`host/account/repository/${process.platform}-${process.arch}/${pkg.version}`
```

in a backwards compatible way.

- `darwin` will be parsed as `darwin-x64`
- `win32` will be parsed as `win32-x64`.

This way, `win32-ia32` will now be supported, if a release contains a file that matches `*win32-ia32*`.

During deployment, the caching layer will properly reuse old cache entries, so no extra pressure is expected from the change of structure in cache objects.

Closes #63.