### PR TITLE
fix: Don't return first exe as x64

### DIFF
--- a/index.js
+++ b/index.js
@@ -271,7 +271,19 @@ const assetPlatform = fileName => {
 
   if (/win32-ia32/.test(fileName)) return PLATFORM_ARCH.WIN_IA32
   if (/win32-arm64/.test(fileName)) return PLATFORM_ARCH.WIN_ARM64
-  if (/win32-x64|(\.exe$)/.test(fileName)) return PLATFORM_ARCH.WIN_X64
+  if (/win32-x64/.test(fileName)) return PLATFORM_ARCH.WIN_X64
+
+  // Special case handling: We don't know what kind of asset
+  // we're looking at, so it might be the default x64 windows
+  // asset
+  if (
+    /\.exe$/.test(fileName) &&
+    !/arm/.test(fileName) &&
+    !/ia32/.test(fileName)
+  ) {
+    return PLATFORM_ARCH.WIN_X64
+  }
+
   return false
 }
 


### PR DESCRIPTION
Without this fix, we're automatically returning the first `exe` we find as `win32/x64`. This used to work just fine: When sorted alphabetically, the first asset ending with `.exe` would usually be the `x64` asset. However, if an app has a `win32-arm64` asset, we'll start serving ARM assets to x64 users.

This PR fixes this issue. 