### PR TITLE
fix: do not issue updates if the latest version is older than the current version

### DIFF
--- a/index.js
+++ b/index.js
@@ -101,7 +101,7 @@ class Updates {
         ? 'No updates found (needs asset matching *{mac,darwin,osx}*.zip in public repository)'
         : 'No updates found (needs asset containing win32-{x64,ia32,arm64} or .exe in public repository)'
       notFound(res, message)
-    } else if (semver.eq(latest.version, version)) {
+    } else if (semver.lte(latest.version, version)) {
       log.info({ account, repository, platform, version }, 'up to date')
       noContent(res)
     } else {


### PR DESCRIPTION
Fixes an issue when testing an unreleased version of an app on macOS where the update server would try and "update" to the older latest release.

cc @nocturnll