### PR TITLE
chore: remove old Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-sudo: false
-language: node_js
-node_js:
-  - 8
-  - 9
-  - 10

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 > A free service that makes it easy for open-source Electron apps to update themselves.
 
-[![Build Status](https://travis-ci.org/electron/update.electronjs.org.svg?branch=main)](https://travis-ci.org/electron/update.electronjs.org)
+[![CircleCI build status](https://circleci.com/gh/electron/update.electronjs.org/tree/main.svg?style=shield)](https://circleci.com/gh/electron/update.electronjs.org/tree/main)
 
 ## Requirements
 


### PR DESCRIPTION
This repo hasn't used Travis CI for quite some time.