### PR TITLE
chore: add private to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "update.electronjs.org",
+  "private": true,
   "scripts": {
     "start": "nodemon bin/update-server.js",
     "start-test-server": "cross-env NODE_ENV=test nodemon bin/test-update-server.js",


### PR DESCRIPTION
Historically we've added `private` to any `package.json` we don't intend to publish.