### PR TITLE
feat: update macOS asset matching

### DIFF
--- a/src/asset-platform.js
+++ b/src/asset-platform.js
@@ -1,11 +1,9 @@
 const { PLATFORM_ARCH } = require("./constants");
 
 const assetPlatform = (fileName) => {
-  if (/.*(mac|darwin|osx).*(-arm).*\.zip/i.test(fileName)) {
-    return PLATFORM_ARCH.DARWIN_ARM64;
-  }
-
-  if (/.*(mac|darwin|osx).*\.zip/i.test(fileName) && !/arm64/.test(fileName)) {
+  if (/.*(mac|darwin|osx).*\.zip/i.test(fileName)) {
+    if (/universal/.test(fileName)) return PLATFORM_ARCH.DARWIN_UNIVERSAL;
+    if (/arm64/.test(fileName)) return PLATFORM_ARCH.DARWIN_ARM64;
     return PLATFORM_ARCH.DARWIN_X64;
   }
 

--- a/src/asset-platform.js
+++ b/src/asset-platform.js
@@ -1,7 +1,7 @@
 const { PLATFORM_ARCH } = require("./constants");
 
 const assetPlatform = (fileName) => {
-  if (/.*(mac|darwin|osx).*\.zip$/i.test(fileName)) {
+  if (/.*-(mac|darwin|osx).*\.zip$/i.test(fileName)) {
     if (/-arm64/.test(fileName)) return PLATFORM_ARCH.DARWIN_ARM64;
     if (/-universal/.test(fileName)) return PLATFORM_ARCH.DARWIN_UNIVERSAL;
 

--- a/src/asset-platform.js
+++ b/src/asset-platform.js
@@ -1,7 +1,7 @@
 const { PLATFORM_ARCH } = require("./constants");
 
 const assetPlatform = (fileName) => {
-  if (/.*(mac|darwin|osx).*\.zip/i.test(fileName)) {
+  if (/.*(mac|darwin|osx).*\.zip$/i.test(fileName)) {
     if (/universal/.test(fileName)) return PLATFORM_ARCH.DARWIN_UNIVERSAL;
     if (/arm64/.test(fileName)) return PLATFORM_ARCH.DARWIN_ARM64;
     return PLATFORM_ARCH.DARWIN_X64;

--- a/src/asset-platform.js
+++ b/src/asset-platform.js
@@ -2,8 +2,9 @@ const { PLATFORM_ARCH } = require("./constants");
 
 const assetPlatform = (fileName) => {
   if (/.*(mac|darwin|osx).*\.zip$/i.test(fileName)) {
-    if (/universal/.test(fileName)) return PLATFORM_ARCH.DARWIN_UNIVERSAL;
-    if (/arm64/.test(fileName)) return PLATFORM_ARCH.DARWIN_ARM64;
+    if (/-arm64/.test(fileName)) return PLATFORM_ARCH.DARWIN_ARM64;
+    if (/-universal/.test(fileName)) return PLATFORM_ARCH.DARWIN_UNIVERSAL;
+
     return PLATFORM_ARCH.DARWIN_X64;
   }
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -6,6 +6,7 @@ const PLATFORM = {
 const PLATFORM_ARCH = {
   DARWIN_X64: "darwin-x64",
   DARWIN_ARM64: "darwin-arm64",
+  DARWIN_UNIVERSAL: "darwin-universal",
   WIN_X64: "win32-x64",
   WIN_IA32: "win32-ia32",
   WIN_ARM64: "win32-arm64",

--- a/src/updates.js
+++ b/src/updates.js
@@ -221,6 +221,7 @@ class Updates {
     for (const release of releases) {
       if (
         !semver.valid(release.tag_name) ||
+        semver.lt(release.tag_name, version) ||
         release.draft ||
         release.prerelease
       ) {

--- a/src/updates.js
+++ b/src/updates.js
@@ -121,7 +121,7 @@ class Updates {
 
     if (!latest) {
       const message = platform.includes(PLATFORM.DARWIN)
-        ? "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
+        ? "No updates found (needs asset matching .*-(mac|darwin|osx).*.zip in public repository)"
         : "No updates found (needs asset containing win32-{x64,ia32,arm64} or .exe in public repository)";
       notFound(res, message);
     } else if (semver.lte(latest.version, version)) {

--- a/src/updates.js
+++ b/src/updates.js
@@ -95,16 +95,27 @@ class Updates {
   }
 
   async handleUpdate(res, account, repository, platform, version) {
-    const latest = await this.cachedGetLatest(
+    let latest = await this.cachedGetLatest(
       account,
       repository,
       platform,
       version
     );
 
+    const latestUniversal = await this.cachedGetLatest(
+      account,
+      repository,
+      PLATFORM_ARCH.DARWIN_UNIVERSAL,
+      version
+    );
+
+    if (!latest && latestUniversal) {
+      latest = latestUniversal;
+    }
+
     if (!latest) {
       const message = platform.includes(PLATFORM.DARWIN)
-        ? "No updates found (needs asset matching *(mac|darwin|osx).*(-arm).*.zip in public repository)"
+        ? "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
         : "No updates found (needs asset containing win32-{x64,ia32,arm64} or .exe in public repository)";
       notFound(res, message);
     } else if (semver.lte(latest.version, version)) {

--- a/test/asset-platform.test.js
+++ b/test/asset-platform.test.js
@@ -29,14 +29,10 @@ test("assetPlatform() matches the right platform", (t) => {
       platform: PLATFORM_ARCH.DARWIN_ARM64,
     },
     {
-      name: "Electron.Fiddle-0.27.3-arm64-mac.zip",
-      platform: PLATFORM_ARCH.DARWIN_ARM64,
-    },
-    {
       name: "Electron.Fiddle-darwin-x64-0.27.3.zip",
       platform: PLATFORM_ARCH.DARWIN_X64,
     },
-    // Electron Builder
+    // Electron Builder default naming conventions
     {
       name: "Electron-Builder-1.2.3-mac.zip",
       platform: PLATFORM_ARCH.DARWIN_X64,

--- a/test/asset-platform.test.js
+++ b/test/asset-platform.test.js
@@ -29,8 +29,25 @@ test("assetPlatform() matches the right platform", (t) => {
       platform: PLATFORM_ARCH.DARWIN_ARM64,
     },
     {
+      name: "Electron.Fiddle-0.27.3-arm64-mac.zip",
+      platform: PLATFORM_ARCH.DARWIN_ARM64,
+    },
+    {
       name: "Electron.Fiddle-darwin-x64-0.27.3.zip",
       platform: PLATFORM_ARCH.DARWIN_X64,
+    },
+    // Electron Builder
+    {
+      name: "Electron-Builder-1.2.3-mac.zip",
+      platform: PLATFORM_ARCH.DARWIN_X64,
+    },
+    {
+      name: "Electron-Builder-1.2.3-universal-mac.zip",
+      platform: PLATFORM_ARCH.DARWIN_UNIVERSAL,
+    },
+    {
+      name: "Electron-Builder-1.2.3-arm64-mac.zip",
+      platform: PLATFORM_ARCH.DARWIN_ARM64,
     },
   ];
 

--- a/test/asset-platform.test.js
+++ b/test/asset-platform.test.js
@@ -45,7 +45,19 @@ test("assetPlatform() matches the right platform", (t) => {
       platform: PLATFORM_ARCH.DARWIN_ARM64,
     },
     {
-      name: "Electron.Fiddle-1.62.6-mac.zip.blockmap",
+      name: "Electron.Builder-1.2.3-mac.zip.blockmap",
+      platform: false,
+    },
+    {
+      name: "mac.zip",
+      platform: false,
+    },
+    {
+      name: "darwin.zip",
+      platform: false,
+    },
+    {
+      name: "osx.zip",
       platform: false,
     },
   ];

--- a/test/asset-platform.test.js
+++ b/test/asset-platform.test.js
@@ -32,7 +32,6 @@ test("assetPlatform() matches the right platform", (t) => {
       name: "Electron.Fiddle-darwin-x64-0.27.3.zip",
       platform: PLATFORM_ARCH.DARWIN_X64,
     },
-    // Electron Builder default naming conventions
     {
       name: "Electron-Builder-1.2.3-mac.zip",
       platform: PLATFORM_ARCH.DARWIN_X64,

--- a/test/asset-platform.test.js
+++ b/test/asset-platform.test.js
@@ -45,6 +45,10 @@ test("assetPlatform() matches the right platform", (t) => {
       name: "Electron-Builder-1.2.3-arm64-mac.zip",
       platform: PLATFORM_ARCH.DARWIN_ARM64,
     },
+    {
+      name: "Electron.Fiddle-1.62.6-mac.zip.blockmap",
+      platform: false,
+    },
   ];
 
   for (const release of releases) {

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -491,7 +491,7 @@ test("Updates", async (t) => {
         const body = await res.text();
         t.equal(
           body,
-          'Unsupported platform: "linux". Supported: darwin-x64, darwin-arm64, win32-x64, win32-ia32, win32-arm64.'
+          'Unsupported platform: "linux". Supported: darwin-x64, darwin-arm64, darwin-universal, win32-x64, win32-ia32, win32-arm64.'
         );
       });
     });
@@ -503,7 +503,7 @@ test("Updates", async (t) => {
         const body = await res.text();
         t.equal(
           body,
-          'Unsupported platform: "os". Supported: darwin-x64, darwin-arm64, win32-x64, win32-ia32, win32-arm64.'
+          'Unsupported platform: "os". Supported: darwin-x64, darwin-arm64, darwin-universal, win32-x64, win32-ia32, win32-arm64.'
         );
       });
     });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -346,7 +346,7 @@ test("Updates", async (t) => {
         let body = await res.text();
         t.equal(
           body,
-          "No updates found (needs asset matching *(mac|darwin|osx).*(-arm).*.zip in public repository)"
+          "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
         );
 
         res = await fetch(`${address}/owner/repo-win32-zip/darwin/0.0.0`);
@@ -354,7 +354,7 @@ test("Updates", async (t) => {
         body = await res.text();
         t.equal(
           body,
-          "No updates found (needs asset matching *(mac|darwin|osx).*(-arm).*.zip in public repository)"
+          "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
         );
       });
     });

--- a/test/update.test.js
+++ b/test/update.test.js
@@ -18,16 +18,16 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "mac.zip",
-          browser_download_url: "mac.zip",
+          name: "app-mac.zip",
+          browser_download_url: "app-mac.zip",
         },
         {
-          name: "mac-arm64.zip",
-          browser_download_url: "mac-arm64.zip",
+          name: "app-mac-arm64.zip",
+          browser_download_url: "app-mac-arm64.zip",
         },
         {
-          name: "universal-mac.zip",
-          browser_download_url: "universal-mac.zip",
+          name: "app-universal-mac.zip",
+          browser_download_url: "app-universal-mac.zip",
         },
         {
           name: "electron-fiddle-1.0.0-win32-x64-setup.exe",
@@ -52,12 +52,12 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "mac.zip",
-          browser_download_url: "mac.zip",
+          name: "app-mac.zip",
+          browser_download_url: "app-mac.zip",
         },
         {
-          name: "mac-arm64.zip",
-          browser_download_url: "mac-arm64.zip",
+          name: "app-mac-arm64.zip",
+          browser_download_url: "app-mac-arm64.zip",
         },
       ],
     },
@@ -74,16 +74,16 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "darwin.zip",
-          browser_download_url: "darwin.zip",
+          name: "app-darwin.zip",
+          browser_download_url: "app-darwin.zip",
         },
         {
-          name: "darwin-arm64.zip",
-          browser_download_url: "darwin-arm64.zip",
+          name: "app-darwin-arm64.zip",
+          browser_download_url: "app-darwin-arm64.zip",
         },
         {
-          name: "universal-mac.zip",
-          browser_download_url: "universal-mac.zip",
+          name: "app-universal-mac.zip",
+          browser_download_url: "app-universal-mac.zip",
         },
       ],
     },
@@ -96,12 +96,12 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "universal-mac.zip",
-          browser_download_url: "universal-mac.zip",
+          name: "app-universal-mac.zip",
+          browser_download_url: "app-universal-mac.zip",
         },
         {
-          name: "arm64-mac.zip",
-          browser_download_url: "arm64-mac.zip",
+          name: "app-arm64-mac.zip",
+          browser_download_url: "app-arm64-mac.zip",
         },
       ],
     },
@@ -111,12 +111,12 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "mac.zip",
-          browser_download_url: "mac.zip",
+          name: "app-mac.zip",
+          browser_download_url: "app-mac.zip",
         },
         {
-          name: "arm64-mac.zip",
-          browser_download_url: "arm64-mac.zip",
+          name: "app-arm64-mac.zip",
+          browser_download_url: "app-arm64-mac.zip",
         },
       ],
     },
@@ -195,12 +195,12 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "mac.zip",
-          browser_download_url: "mac.zip",
+          name: "app-mac.zip",
+          browser_download_url: "app-mac.zip",
         },
         {
-          name: "mac-arm64.zip",
-          browser_download_url: "mac-arm64.zip",
+          name: "app-mac-arm64.zip",
+          browser_download_url: "app-mac-arm64.zip",
         },
         {
           name: "electron-fiddle-0.36.0-win32-x64-setup.exe",
@@ -225,12 +225,12 @@ nock("https://api.github.com")
       body: "notes",
       assets: [
         {
-          name: "mac.zip",
-          browser_download_url: "mac.zip",
+          name: "app-mac.zip",
+          browser_download_url: "app-mac.zip",
         },
         {
-          name: "mac-arm64.zip",
-          browser_download_url: "mac-arm64.zip",
+          name: "app-mac-arm64.zip",
+          browser_download_url: "app-mac-arm64.zip",
         },
         {
           name: "electron-fiddle-1.0.0-win32-x64-setup.exe",
@@ -284,7 +284,7 @@ test("Updates", async (t) => {
         const body = await res.json();
         t.same(body, {
           name: "name",
-          url: "mac.zip",
+          url: "app-mac.zip",
           notes: "notes",
         });
       }
@@ -350,44 +350,44 @@ test("Updates", async (t) => {
           let res = await fetch(`${address}/owner/repo/darwin-x64/0.0.0`);
           t.equal(res.status, 200);
           let body = await res.json();
-          t.equal(body.url, "mac.zip");
+          t.equal(body.url, "app-mac.zip");
 
           res = await fetch(`${address}/owner/repo/darwin-arm64/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.equal(body.url, "mac-arm64.zip");
+          t.equal(body.url, "app-mac-arm64.zip");
 
           res = await fetch(`${address}/owner/repo/darwin/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.equal(body.url, "mac.zip");
+          t.equal(body.url, "app-mac.zip");
 
           res = await fetch(`${address}/owner/repo/darwin-universal/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.equal(body.url, "universal-mac.zip");
+          t.equal(body.url, "app-universal-mac.zip");
 
           res = await fetch(`${address}/owner/repo-darwin/darwin-x64/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.match(body.url, "darwin.zip");
+          t.match(body.url, "app-darwin.zip");
 
           res = await fetch(`${address}/owner/repo-darwin/darwin-arm64/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.match(body.url, "darwin-arm64.zip");
+          t.match(body.url, "app-darwin-arm64.zip");
 
           res = await fetch(`${address}/owner/repo-darwin/darwin/0.0.0`);
           t.equal(res.status, 200);
           body = await res.json();
-          t.match(body.url, "darwin.zip");
+          t.match(body.url, "app-darwin.zip");
 
           res = await fetch(
             `${address}/owner/repo-darwin/darwin-universal/0.0.0`
           );
           t.equal(res.status, 200);
           body = await res.json();
-          t.match(body.url, "universal-mac.zip");
+          t.match(body.url, "app-universal-mac.zip");
         }
       });
 
@@ -399,7 +399,7 @@ test("Updates", async (t) => {
         let body = await res.text();
         t.equal(
           body,
-          "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
+          "No updates found (needs asset matching .*-(mac|darwin|osx).*.zip in public repository)"
         );
 
         res = await fetch(`${address}/owner/repo-win32-zip/darwin/0.0.0`);
@@ -407,7 +407,7 @@ test("Updates", async (t) => {
         body = await res.text();
         t.equal(
           body,
-          "No updates found (needs asset matching *(mac|darwin|osx).*.zip in public repository)"
+          "No updates found (needs asset matching .*-(mac|darwin|osx).*.zip in public repository)"
         );
       });
 
@@ -420,7 +420,7 @@ test("Updates", async (t) => {
             );
             t.equal(res.status, 200);
             let body = await res.json();
-            t.match(body.url, "universal-mac.zip");
+            t.match(body.url, "app-universal-mac.zip");
           }
         );
 
@@ -432,7 +432,7 @@ test("Updates", async (t) => {
             );
             t.equal(res.status, 200);
             let body = await res.json();
-            t.match(body.url, "arm64-mac.zip");
+            t.match(body.url, "app-arm64-mac.zip");
           }
         );
       });


### PR DESCRIPTION
Resolves #168, #140, #166, #113

Updates the macOS (darwin) asset matching logic to 
1. Add support for electron-builder arm64 asset naming convention
2. Add support for electron-builder universal asset naming convention
3. Fallback to universal build if no specific macOS release found (ie: arm64 or x64), or universal asset is deemed more recent.
4. Ignore assets that don't end with `.zip` (eg: blockmap assets)
5. Ensure that suggested latest assets do indeed have a newer version than that currently running