### PR TITLE
fix: handle darwin releases with only universal builds

### DIFF
--- a/src/updates.js
+++ b/src/updates.js
@@ -109,6 +109,7 @@ class Updates {
         PLATFORM_ARCH.DARWIN_UNIVERSAL,
         version
       );
+      latest = latest || latestUniversal;
 
       if (
         latestUniversal &&


### PR DESCRIPTION
Noticed a bunch of 500 errors on the darwin endpoints, this ensures that `latest` is defined as the universal one if there isn't otherwise a "latest" build available