### PR TITLE
fix: cache key collision vulnerability in release updates

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -250,7 +250,16 @@ export default class Updates {
   ): Promise<LatestRelease | null> {
     const tag = needsSpecificReleaseTag(account, repository, platform, version);
 
-    const key = tag ? `${account}/${repository}-${tag}` : `${account}/${repository}`;
+    // Encode each user-controlled segment and use `/` (which cannot appear
+    // within a single URL path segment) as the tag delimiter, so that the tag
+    // namespace can never collide with a repository name. Without this, a
+    // request for repository `foo-<tag>` (no tag) would produce the same key
+    // as repository `foo` with tag `<tag>`, allowing cache poisoning.
+    const encodedAccount = encodeURIComponent(account);
+    const encodedRepository = encodeURIComponent(repository);
+    const key = tag
+      ? `${encodedAccount}/${encodedRepository}/${encodeURIComponent(tag)}`
+      : `${encodedAccount}/${encodedRepository}`;
     let latest = await this.cache.get(key);
 
     if (latest) {


### PR DESCRIPTION
## Summary
This change fixes a security vulnerability in the cache key generation for release updates by properly encoding user-controlled input and using a delimiter that cannot appear in encoded segments.

## Key Changes
- **Encode cache key segments**: Added `encodeURIComponent()` calls for `account`, `repository`, and `tag` to safely handle special characters
- **Use `/` as delimiter**: Changed the cache key format to use `/` as a separator between segments, which cannot appear within an encoded URL path segment
- **Prevent cache poisoning**: This prevents a collision where a repository named `foo-<tag>` (without a tag) would previously generate the same cache key as repository `foo` with tag `<tag>`

## Implementation Details
The cache key format changed from:
- `account/repository` or `account/repository-tag`

To:
- `account/repository` or `account/repository/tag`

Where each segment is URL-encoded. This ensures that special characters in account names, repository names, or tags cannot create ambiguous keys that could lead to cache poisoning attacks.

https://claude.ai/code/session_0169Z2ZYnhjVrnK4ELxcuAYo