### PR TITLE
chore: remove ENV-based error exposure and always return generic error

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -13,7 +13,6 @@ import {
   UPDATE_FORMAT,
   UPDATE_FORMATS,
   SQUIRREL_TO_MSIX,
-  ENV,
   type PlatformArch,
   type UpdateFormat,
 } from './constants.ts';
@@ -82,8 +81,9 @@ export default class Updates {
         .catch((err: any) => {
           log.error(err);
           res.statusCode = err.statusCode || 500;
-          const msg = ENV === 'production' ? 'Internal Server Error' : err.stack;
-          res.end(msg);
+          // Never expose stack traces or internal details to remote clients;
+          // detailed diagnostics are captured in the server-side log above.
+          res.end('Internal Server Error');
         })
         .then(() => {
           log.debug(


### PR DESCRIPTION
## Summary
Improved security by removing environment-based conditional error handling that could expose sensitive stack traces to remote clients.

## Key Changes
- Removed unused `ENV` import from constants
- Changed error response handling to always return a generic "Internal Server Error" message instead of conditionally exposing stack traces in non-production environments
- Added clarifying comment explaining that detailed diagnostics are captured server-side in logs

## Implementation Details
Previously, the error handler would expose the full error stack trace (`err.stack`) when not in production, which could leak sensitive information about the application's internal structure and implementation details to remote clients. This change ensures that all remote clients receive only a generic error message, while detailed diagnostics remain available in server-side logs for debugging purposes.

https://claude.ai/code/session_016N2EsCU1GTq1kEDtJmxccW