### PR TITLE
fix: cache lock leaks on getLatest failures

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -271,28 +271,43 @@ export default class Updates {
       log.debug({ key }, 'lock acquiring');
       lock = await this.cache.lock(key);
       log.debug({ key }, 'lock acquired');
-      latest = await this.cache.get(key);
-      if (latest) {
-        log.debug({ key }, 'cache hit after lock');
-        return latest[platform] ? latest[platform]! : null;
+    }
+
+    try {
+      if (lock) {
+        latest = await this.cache.get(key);
+        if (latest) {
+          log.debug({ key }, 'cache hit after lock');
+          return latest[platform] ? latest[platform]! : null;
+        }
+      }
+
+      try {
+        latest = await this.getLatest(account, repository, platform, version);
+
+        if (latest) {
+          await this.cache.set(key, latest);
+        } else {
+          await this.cache.set(key, {});
+        }
+      } catch (err) {
+        // Record a negative cache entry on failure so a single failing release
+        // fetch cannot repeatedly deny updates for this repository while the
+        // error condition persists.
+        await this.cache.set(key, {});
+        throw err;
+      }
+
+      return latest && latest[platform] ? latest[platform]! : null;
+    } finally {
+      // Always release the lock, even when getLatest or cache.set throws, so a
+      // failing request never leaves the distributed lock held for its TTL.
+      if (lock) {
+        log.debug({ key }, 'lock releasing');
+        await lock.unlock();
+        log.debug({ key }, 'lock released');
       }
     }
-
-    latest = await this.getLatest(account, repository, platform, version);
-
-    if (latest) {
-      await this.cache.set(key, latest);
-    } else {
-      await this.cache.set(key, {});
-    }
-
-    if (lock) {
-      log.debug({ key }, 'lock releasing');
-      await lock.unlock();
-      log.debug({ key }, 'lock released');
-    }
-
-    return latest && latest[platform] ? latest[platform]! : null;
   }
 
   async getLatest(

--- a/test/cache.test.ts
+++ b/test/cache.test.ts
@@ -39,6 +39,10 @@ class MemoryCacheWithLock {
       },
     };
   }
+
+  isLocked(key: string): boolean {
+    return Boolean(this.locks.get(`locks:${key}`)) || Boolean(this.locks.get(key));
+  }
 }
 
 describe('Cache Locking', () => {
@@ -132,6 +136,78 @@ describe('Cache Locking', () => {
     const res2 = await fetch(`${address}/owner/cached-repo/darwin-x64/0.0.0`);
     expect(res2.status).toBe(200);
     expect(apiCallCount).toBe(1); // No additional API call
+  });
+});
+
+describe('Cache Lock Release on Failure', () => {
+  let server: http.Server;
+  let address: string;
+  let cache: MemoryCacheWithLock;
+
+  beforeAll(async () => {
+    cache = new MemoryCacheWithLock();
+    const updates = new Updates({ cache });
+    server = await new Promise((resolve) => {
+      const s = updates.listen(() => resolve(s));
+    });
+    const addr = server.address();
+    const port = typeof addr === 'object' && addr !== null ? addr.port : 3000;
+    address = `http://localhost:${port}`;
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  beforeEach(() => {
+    nock.cleanAll();
+  });
+
+  it('releases the lock and records a negative cache entry when getLatest throws', async () => {
+    // A RELEASES file without any .nupkg token makes getLatest throw at
+    // assert(matches). The lock must still be released so the repo endpoint is
+    // not wedged for the full lock TTL.
+    nock('https://api.github.com')
+      .get('/repos/owner/broken-repo/releases?per_page=100')
+      .reply(200, [
+        {
+          name: 'Release',
+          tag_name: 'v1.0.0',
+          body: 'notes',
+          assets: [
+            {
+              name: 'app-win32-x64-setup.exe',
+              browser_download_url: 'app-win32-x64-setup.exe',
+            },
+          ],
+        },
+      ]);
+
+    nock('https://github.com')
+      .get('/owner/broken-repo/releases/download/v1.0.0/RELEASES')
+      .reply(200, 'INVALID FORMAT WITHOUT NUPKG');
+
+    const res = await fetch(`${address}/owner/broken-repo/win32-x64/0.0.0/RELEASES`);
+    expect(res.status).toBe(500);
+
+    // The distributed lock must not be leaked after the failure.
+    expect(cache.isLocked('owner/broken-repo')).toBe(false);
+
+    // A negative cache entry should have been recorded so subsequent requests
+    // do not re-trigger the failing fetch and cannot be used to keep denying
+    // updates for the repository.
+    expect(await cache.get('owner/broken-repo')).toEqual({});
+  });
+
+  it('serves the negative cache on subsequent requests instead of re-locking', async () => {
+    // Prime the negative cache directly.
+    await cache.set('owner/cached-broken-repo', {});
+
+    // No nock interceptors are registered: if the code tried to fetch again it
+    // would throw a network error. A cache hit avoids the lock entirely.
+    const res = await fetch(`${address}/owner/cached-broken-repo/win32-x64/0.0.0/RELEASES`);
+    expect(res.status).toBe(404);
+    expect(cache.isLocked('owner/cached-broken-repo')).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary
This PR fixes a critical issue where distributed cache locks could be held indefinitely when `getLatest()` fails, potentially wedging repository endpoints for the full lock TTL. The fix ensures locks are always released and negative cache entries are recorded on failures.

## Key Changes
- **Added `isLocked()` helper method** to `MemoryCacheWithLock` test class to check lock status
- **Restructured error handling** in `Updates.check()` with try-finally to guarantee lock release:
  - Moved cache check inside the try block (after lock acquisition)
  - Wrapped `getLatest()` call in inner try-catch to record negative cache entries on failure
  - Added finally block to always release locks, even when errors occur
- **Negative cache entries on failure**: When `getLatest()` throws, a negative cache entry (`{}`) is recorded to prevent repeated failed fetches from repeatedly acquiring locks
- **Added comprehensive test suite** covering:
  - Lock release when `getLatest()` throws (with negative cache entry verification)
  - Subsequent requests serving negative cache without re-locking

## Implementation Details
The fix uses nested try-catch-finally blocks:
1. Outer try-finally ensures the lock is always released
2. Inner try-catch around `getLatest()` records a negative cache entry before re-throwing
3. Cache check is deferred until after lock acquisition to avoid race conditions
4. Negative cache entries (`{}`) serve as a circuit breaker for failing repositories, preventing lock thrashing while the error persists

https://claude.ai/code/session_01Uckzj5aE54CH7hydotcfiV