### PR TITLE
chore: add Content-Type and X-Content-Type-Options headers to responses

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -179,6 +179,8 @@ export default class Updates {
   ): Promise<void> {
     const latest = await this.cachedGetLatest(account, repository, platform, version);
     if (!latest || !latest.RELEASES) return notFound(res);
+    res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+    res.setHeader('X-Content-Type-Options', 'nosniff');
     res.end(latest.RELEASES);
   }
 
@@ -409,11 +411,15 @@ const hasAnyAsset = (latest: LatestReleases): boolean => {
 
 const notFound = (res: http.ServerResponse, message = 'Not found'): void => {
   res.statusCode = 404;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
   res.end(message);
 };
 
 const badRequest = (res: http.ServerResponse, message: string): void => {
   res.statusCode = 400;
+  res.setHeader('Content-Type', 'text/plain; charset=utf-8');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
   res.end(message);
 };
 


### PR DESCRIPTION
## Summary
This PR adds explicit `Content-Type` and `X-Content-Type-Options` headers to HTTP responses to improve security and ensure proper content handling.

## Key Changes
- Added `Content-Type: text/plain; charset=utf-8` and `X-Content-Type-Options: nosniff` headers to the RELEASES endpoint response
- Added the same headers to the `notFound()` error response handler
- Added the same headers to the `badRequest()` error response handler

## Implementation Details
These headers are set before calling `res.end()` to ensure they are included in all responses from these endpoints. The `X-Content-Type-Options: nosniff` header prevents browsers from MIME-type sniffing, which is a security best practice. Explicitly setting the `Content-Type` header ensures clients correctly interpret the response as plain text with UTF-8 encoding.

https://claude.ai/code/session_01QFW7BGwu38yJoLZvb9rqQw