### PR TITLE
fix: ReDoS vulnerability in RELEASES file parsing

### DIFF
--- a/src/updates.ts
+++ b/src/updates.ts
@@ -22,6 +22,61 @@ const log = pino({
   level: process.env.NODE_ENV === 'test' ? 'error' : 'info',
 });
 
+// Upper bound on the size of a RELEASES asset we are willing to read from an
+// untrusted, externally-hosted release. RELEASES files describe Squirrel.Windows
+// packages and are only ever a few lines long; this cap is far larger than any
+// legitimate file while preventing an attacker-controlled release from forcing
+// the server to buffer (and scan) unbounded content.
+const MAX_RELEASES_BYTES = 10 * 1024 * 1024;
+
+// Read the response body as UTF-8 text, stopping once maxBytes have been read.
+// fetch()'s Response.text() reads the entire body regardless of size, so we
+// consume the stream manually to enforce a hard limit on untrusted input.
+const readBoundedText = async (res: Response, maxBytes: number): Promise<string> => {
+  const reader = res.body?.getReader();
+  if (!reader) return '';
+
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (total < maxBytes) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+      total += value.byteLength;
+    }
+  } finally {
+    await reader.cancel().catch(() => {});
+  }
+
+  let buf = Buffer.concat(chunks);
+  if (buf.byteLength > maxBytes) buf = buf.subarray(0, maxBytes);
+  return buf.toString('utf8');
+};
+
+// Locate the first whitespace-delimited (space-separated) token that references
+// a `.nupkg` package in a RELEASES file. This replaces a `/[^ ]*\.nupkg/` regex
+// whose greedy quantifier backtracked quadratically on long runs of non-space
+// characters that never matched. The scan below is strictly linear in the size
+// of the input so untrusted content cannot cause super-linear CPU consumption.
+const findNupkgName = (body: string): string | null => {
+  const marker = '.nupkg';
+  const idx = body.toLowerCase().indexOf(marker);
+  if (idx === -1) return null;
+
+  // Expand to the surrounding space-delimited run. `[^ ]` in the original regex
+  // excluded only the literal space character (0x20), so we match that exactly.
+  let start = idx;
+  while (start > 0 && body[start - 1] !== ' ') start--;
+  let runEnd = idx + marker.length;
+  while (runEnd < body.length && body[runEnd] !== ' ') runEnd++;
+
+  // The greedy quantifier consumed the whole run then backtracked to the last
+  // `.nupkg` within it; reproduce that by taking the final occurrence in the run.
+  const lastRel = body.slice(start, runEnd).toLowerCase().lastIndexOf(marker);
+  return body.slice(start, start + lastRel + marker.length);
+};
+
 interface Asset {
   name: string;
   browser_download_url: string;
@@ -355,11 +410,11 @@ export default class Updates {
         const rurl = `https://github.com/${account}/${repository}/releases/download/${releaseForKey.version}/RELEASES`;
         const rres = await fetch(rurl);
         if (rres.status < 400) {
-          const body = await rres.text();
-          const matches = body.match(/[^ ]*\.nupkg/gim);
-          assert(matches);
-          const nuPKG = rurl.replace('RELEASES', matches[0]!);
-          releaseForKey.RELEASES = body.replace(matches[0]!, nuPKG);
+          const body = await readBoundedText(rres, MAX_RELEASES_BYTES);
+          const nupkgName = findNupkgName(body);
+          assert(nupkgName);
+          const nuPKG = rurl.replace('RELEASES', nupkgName);
+          releaseForKey.RELEASES = body.replace(nupkgName, nuPKG);
         }
       }
     }

--- a/test/releases.test.ts
+++ b/test/releases.test.ts
@@ -107,6 +107,72 @@ describe('RELEASES File Edge Cases', () => {
     );
   });
 
+  it('handles a large RELEASES file without a .nupkg in bounded time', async () => {
+    nock('https://api.github.com')
+      .get('/repos/owner/redos-releases/releases?per_page=100')
+      .reply(200, [
+        {
+          name: 'Release',
+          tag_name: 'v1.0.0',
+          body: 'notes',
+          assets: [
+            {
+              name: 'app-win32-x64-setup.exe',
+              browser_download_url: 'app-win32-x64-setup.exe',
+            },
+          ],
+        },
+      ]);
+
+    // A multi-megabyte run of a single non-space, non-dot character with no
+    // `.nupkg` substring. The previous `/[^ ]*\.nupkg/` regex backtracked
+    // quadratically on this input; the linear scan must handle it quickly.
+    nock('https://github.com')
+      .get('/owner/redos-releases/releases/download/v1.0.0/RELEASES')
+      .reply(200, 'a'.repeat(8 * 1024 * 1024));
+
+    const start = Date.now();
+    const res = await fetch(`${address}/owner/redos-releases/win32-x64/0.0.0/RELEASES`);
+    const elapsed = Date.now() - start;
+
+    // No .nupkg means the assertion still fails (500), but it must return fast.
+    expect(res.status).toBe(500);
+    expect(elapsed).toBeLessThan(5000);
+  });
+
+  it('finds the .nupkg token even after a large leading run of non-space bytes', async () => {
+    nock('https://api.github.com')
+      .get('/repos/owner/big-nupkg/releases?per_page=100')
+      .reply(200, [
+        {
+          name: 'Release',
+          tag_name: 'v1.0.0',
+          body: 'notes',
+          assets: [
+            {
+              name: 'app-win32-x64-setup.exe',
+              browser_download_url: 'app-win32-x64-setup.exe',
+            },
+          ],
+        },
+      ]);
+
+    nock('https://github.com')
+      .get('/owner/big-nupkg/releases/download/v1.0.0/RELEASES')
+      .reply(200, `${'a'.repeat(4 * 1024 * 1024)} HASH real.nupkg SIZE`);
+
+    const start = Date.now();
+    const res = await fetch(`${address}/owner/big-nupkg/win32-x64/0.0.0/RELEASES`);
+    const elapsed = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    const body = await res.text();
+    expect(body).toMatch(
+      /https:\/\/github\.com\/owner\/big-nupkg\/releases\/download\/v1\.0\.0\/real\.nupkg/,
+    );
+    expect(elapsed).toBeLessThan(5000);
+  });
+
   it('handles empty RELEASES file', async () => {
     nock('https://api.github.com')
       .get('/repos/owner/empty-releases/releases?per_page=100')


### PR DESCRIPTION
## Summary
This PR fixes a Regular Expression Denial of Service (ReDoS) vulnerability in the RELEASES file parsing logic that could cause the server to hang on untrusted input. The vulnerability existed in the regex `/[^ ]*\.nupkg/gim` which could backtrack quadratically on long runs of non-space characters.

## Key Changes
- **Added bounded text reading**: Implemented `readBoundedText()` function that enforces a 10MB size limit when reading RELEASES files from untrusted external sources, preventing unbounded buffering attacks
- **Replaced vulnerable regex with linear scan**: Replaced the problematic `/[^ ]*\.nupkg/` regex with `findNupkgName()` function that performs a strictly linear-time search for `.nupkg` tokens, eliminating the ReDoS vulnerability
- **Added comprehensive test coverage**: Added two new test cases:
  - One verifying that large RELEASES files without `.nupkg` are rejected quickly (within 5 seconds)
  - One verifying that `.nupkg` tokens are correctly found even after large leading runs of non-space bytes

## Implementation Details
- The `findNupkgName()` function locates the first `.nupkg` marker and expands outward to find the complete space-delimited token, matching the original regex behavior while maintaining O(n) complexity
- The function correctly handles the original regex's greedy backtracking behavior by finding the last occurrence of `.nupkg` within the identified token run
- Both functions include detailed comments explaining the security implications and design decisions

https://claude.ai/code/session_018ago1QYfEqypjdeSy1yoHw